### PR TITLE
cjimti/iotwifi -> txn2/txwifi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM arm32v6/golang:1.10.1-alpine3.7 AS builder
 ENV GOPATH /go
 WORKDIR /go/src
 
-RUN mkdir -p /go/src/github.com/cjimti/iotwifi
-COPY . /go/src/github.com/cjimti/iotwifi
+RUN mkdir -p /go/src/github.com/txn2/txwifi
+COPY . /go/src/github.com/txn2/txwifi
 
-RUN CGO_ENABLED=0 go build -a -installsuffix cgo -o /go/bin/wifi /go/src/github.com/cjimti/iotwifi/main.go
+RUN CGO_ENABLED=0 go build -a -installsuffix cgo -o /go/bin/wifi /go/src/github.com/txn2/txwifi/main.go
 
 FROM arm32v6/alpine
 

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/cjimti/iotwifi",
+	"ImportPath": "github.com/txn2/txwifi",
 	"GoVersion": "go1.9",
 	"GodepVersion": "v80",
 	"Deps": [

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE    ?= cjimti/iotwifi
-NAME     ?= iotwifi
+NAME     ?= txwifi
 VERSION  ?= 1.0.4
 
 all: build push
@@ -19,8 +19,8 @@ dev_build:
 
 dev_run:
 	sudo docker run --rm -it --privileged --network=host \
-                   -v $(CURDIR):/go/src/github.com/cjimti/iotwifi \
-                   -w /go/src/github.com/cjimti/iotwifi \
+                   -v $(CURDIR):/go/src/github.com/txn2/txwifi \
+                   -w /go/src/github.com/txn2/txwifi \
                    --name=$(NAME) $(IMAGE):latest
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-**Update** 2018-12-01. I am archiving this project. The original use case was to enable the configuration of wifi, over wifi, like many IOT devices on the market. It has worked well for me for this purpose. However, many of the issues people have been reporting as bugs are simply other opinions on how it should work for them, and outside of the original use case. Unfortunately, I don't have the personal resources to help in these requests. If others are willing to be contributors I would be grateful; until then, this project is for reference only.
+**Update - 20180601**: Any future development will happen on this new fork. Hoping add stability as well as new SOCs. If you are interesrted in joining the [txn2](https://txn2.com) team please email human@txn2.com.
 
-**Update**: Looking for contributors / maintainers.
+**Update**: Tested and functioning on well on the [Raspberry Pi 3 B+](https://amzn.to/2jfXhCA) and [Raspberry Pi 3 B](https://amzn.to/2Kq9Doa). Looking to support additional SOCs in upcoming versions. (Disclosure: the Pi links to Amazon are affiliate links, why not?)
 
 **NOTICE**: This project is intended to aid in developing "configure wifi over wifi" solutions for IOT projects using the Raspberry Pi. The main use case for this project is to reproduce functionality common to devices like Nest or Echo, where the user turns on the device, connects to it and configures it for wifi. I have over 800 devices running this software in production and all have had their wifi configured using it. 
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 **This is not a captive portal project. While I have personaly used it for this, it requires additional networking and can be unstable. I don't support this use and so your millage may vary.**
 
-**iotwifi** is only expected to run properly on stock Raspberry Pis and not tested on any other hardware configurations.
+**txwifi** is only expected to run properly on stock Raspberry Pis and not tested on any other hardware configurations.
 
 # IOT Wifi (Raspberry Pi AP + Client)
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/cjimti/iotwifi)](https://goreportcard.com/report/github.com/cjimti/iotwifi)
-[![GoDoc](https://godoc.org/github.com/cjimti/iotwifi/iotwifi?status.svg)](https://godoc.org/github.com/cjimti/iotwifi/iotwifi)
+[![Go Report Card](https://goreportcard.com/badge/github.com/txn2/txwifi)](https://goreportcard.com/report/github.com/txn2/txwifi)
+[![GoDoc](https://godoc.org/github.com/txn2/txwifi/iotwifi?status.svg)](https://godoc.org/github.com/txn2/txwifi/iotwifi)
 [![Docker Container Image Size](https://shields.beevelop.com/docker/image/image-size/cjimti/iotwifi/latest.svg)](https://hub.docker.com/r/cjimti/iotwifi/)
 [![Docker Container Layers](https://shields.beevelop.com/docker/image/layers/cjimti/iotwifi/latest.svg)](https://hub.docker.com/r/cjimti/iotwifi/)
 [![Docker Container Pulls](https://img.shields.io/docker/pulls/cjimti/iotwifi.svg)](https://hub.docker.com/r/cjimti/iotwifi/)
@@ -131,7 +131,7 @@ started quickly I'll show you how to use a pre-built Docker Image. At
 only 16MB this little image contains everything you need. The image
 is based on [Alpine Linux] and contains [hostapd], [wpa_supplicant] and
 [dnsmasq], along with a compiled wifi management utility written in go,
-the source is found in this repository: https://github.com/cjimti/iotwifi.
+the source is found in this repository: https://github.com/txn2/txwifi.
 
 ```bash
 # Pull the IOT Wifi Docker Image
@@ -152,7 +152,7 @@ Use the default configuration file and location for testing:
 ```bash
 # Download the default configuration file
 
-$ wget https://raw.githubusercontent.com/cjimti/iotwifi/master/cfg/wificfg.json
+$ wget https://raw.githubusercontent.com/txn2/txwifi/master/cfg/wificfg.json
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **NOTICE**: This project is intended to aid in developing "configure wifi over wifi" solutions for IOT projects using the Raspberry Pi. The main use case for this project is to reproduce functionaly common to deivces like Nest or Echo, where the user turns on the device, connects to it and confiures it for wifi. I have over 800 devices running this software in production and all have had their wifi configured using it. 
 
-**This is not a captive portal project. While I have personaly used it for this, it requires additional networking and can be unstable. I don't support this use and so your millage may vary.***
+**This is not a captive portal project. While I have personaly used it for this, it requires additional networking and can be unstable. I don't support this use and so your millage may vary.**
 
-**iotwifi** is only expected to run properly on stock Raspberry Pis not not tested on any other hardware configurations.
+**iotwifi** is only expected to run properly on stock Raspberry Pis and not tested on any other hardware configurations.
 
 # IOT Wifi (Raspberry Pi AP + Client)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Update - 20180429**: Due to my day job taking up some additional time, version 2 will be released in 2-3 weeks. I am shooting for June at the latest. If you are interested in joining this project as a contributor please open an issue. Version 2 aims to split up the host and client functionality and add more fine-grain control and configuration. I also have a contributor interested in releasing a web GUI as an add-on. The essence of the project will however remain JSON based API control of wifi.
+**Update - 20180601**: Created a new fork at https://github.com/txn2/txwifi where any future development should happen. **Looking for contributors**. If you are interested in joining the [txn2][https://txn2.com] team please send an email with your github username to human@txn2.com.
 
 **Update**: Tested and functioning on well on the [Raspberry Pi 3 B+](https://amzn.to/2jfXhCA) and [Raspberry Pi 3 B](https://amzn.to/2Kq9Doa). Looking to support additional SOCs in upcoming versions. (Disclosure: the Pi links to Amazon are affiliate links, why not?)
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,17 @@ $ docker run --rm --privileged --net host \
       cjimti/iotwifi
 ```
 
+Optionally, you can also provide a `wpa_supplicant.conf`, like so:
+
+```bash
+$ docker run --rm --privileged --net host \
+      -v $(pwd)/wificfg.json:/cfg/wificfg.json \
+      -v <HOST_PATH>/wpa_supplicant.conf:<CONTAINER_PATH>/wpa_supplicant.conf \
+      cjimti/iotwifi
+```
+
+Where `<CONTAINER_PATH>` is the path to `wpa_supplicant.conf` specified in `wificfg.json`.
+
 The IOT Wifi container outputs logs in the JSON format. While this makes
 them a bit more challenging to read, we can feed them directly (or indirectly)
 into tools like Elastic Search or other databases for alerting or analytics.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-**Update**: Looking for contributors. 
+**Update**: Looking for contributors.
+
+**NOTICE**: This project is intended to aid in developing "configure wifi over wifi" solutions for IOT projects using the Raspberry Pi. The main use case for this project is to reproduce functionaly common to deivces like Nest or Echo, where the user turns on the deice, connects to it and confiures it for wifi. 
+
+**This is not a captive portal project. While I have personaly used it for this, it requires additional netoworking and can be higly unstable. I don't support this use and so your millage may vary.***
+
+**iotwifi** is only expected to run properly on stock Raspberry Pis not not tested on any other hardware configurations.
 
 # IOT Wifi (Raspberry Pi AP + Client)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Update - 20180601**: Created a new fork at https://github.com/txn2/txwifi where any future development should happen. **Looking for contributors**. If you are interested in joining the [txn2][https://txn2.com] team please send an email with your github username to human@txn2.com.
+**Update - 20180601**: Created a new fork at https://github.com/txn2/txwifi where any future development should happen. **Looking for contributors**. If you are interested in joining the [txn2](https://txn2.com) team please send an email with your github username to human@txn2.com.
 
 **Update**: Tested and functioning on well on the [Raspberry Pi 3 B+](https://amzn.to/2jfXhCA) and [Raspberry Pi 3 B](https://amzn.to/2Kq9Doa). Looking to support additional SOCs in upcoming versions. (Disclosure: the Pi links to Amazon are affiliate links, why not?)
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ with the **IOT Wifi** container.
 # prevent wpa_supplicant from starting on boot
 $ sudo systemctl mask wpa_supplicant.service
 
+# rename wpa_supplicant on the host to ensure that it is not
+# used.
+sudo mv /sbin/wpa_supplicant /sbin/no_wpa_supplicant
+
 # kill any running processes named wpa_supplicant
 $ sudo pkill wpa_supplicant
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-**Update**: Looking for contributors.
+**Update**: Looking for contributors / maintainers.
 
-**NOTICE**: This project is intended to aid in developing "configure wifi over wifi" solutions for IOT projects using the Raspberry Pi. The main use case for this project is to reproduce functionaly common to deivces like Nest or Echo, where the user turns on the deice, connects to it and confiures it for wifi. 
+**NOTICE**: This project is intended to aid in developing "configure wifi over wifi" solutions for IOT projects using the Raspberry Pi. The main use case for this project is to reproduce functionaly common to deivces like Nest or Echo, where the user turns on the device, connects to it and confiures it for wifi. I have over 800 devices running this software in production and all have had their wifi configured using it. 
 
-**This is not a captive portal project. While I have personaly used it for this, it requires additional netoworking and can be higly unstable. I don't support this use and so your millage may vary.***
+**This is not a captive portal project. While I have personaly used it for this, it requires additional networking and can be unstable. I don't support this use and so your millage may vary.***
 
 **iotwifi** is only expected to run properly on stock Raspberry Pis not not tested on any other hardware configurations.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-**Update - 20180601**: Created a new fork at https://github.com/txn2/txwifi where any future development should happen. **Looking for contributors**. If you are interested in joining the [txn2](https://txn2.com) team please send an email with your github username to human@txn2.com.
-
-**Update**: Tested and functioning on well on the [Raspberry Pi 3 B+](https://amzn.to/2jfXhCA) and [Raspberry Pi 3 B](https://amzn.to/2Kq9Doa). Looking to support additional SOCs in upcoming versions. (Disclosure: the Pi links to Amazon are affiliate links, why not?)
+**Update**: Looking for contributors. 
 
 # IOT Wifi (Raspberry Pi AP + Client)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+**Update** 2018-12-01. I am archiving this project. The original use case was to enable the configuration of wifi, over wifi, like many IOT devices on the market. It has worked well for me for this purpose. However, many of the issues people have been reporting as bugs are simply other opinions on how it should work for them, and outside of the original use case. Unfortunately, I don't have the personal resources to help in these requests. If others are willing to be contributors I would be grateful; until then, this project is for reference only.
+
 **Update**: Looking for contributors / maintainers.
 
-**NOTICE**: This project is intended to aid in developing "configure wifi over wifi" solutions for IOT projects using the Raspberry Pi. The main use case for this project is to reproduce functionaly common to deivces like Nest or Echo, where the user turns on the device, connects to it and confiures it for wifi. I have over 800 devices running this software in production and all have had their wifi configured using it. 
+**NOTICE**: This project is intended to aid in developing "configure wifi over wifi" solutions for IOT projects using the Raspberry Pi. The main use case for this project is to reproduce functionality common to devices like Nest or Echo, where the user turns on the device, connects to it and configures it for wifi. I have over 800 devices running this software in production and all have had their wifi configured using it. 
 
 **This is not a captive portal project. While I have personaly used it for this, it requires additional networking and can be unstable. I don't support this use and so your millage may vary.**
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add alpine-sdk go bridge hostapd wireless-tools wireless-tools-dev wpa_s
 RUN mkdir -p /etc/wpa_supplicant/
 COPY ./configs/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf
 
-RUN mkdir -p /go/src/github.com/cjimti/iotwifi/
+RUN mkdir -p /go/src/github.com/tnx2/txwifi/
 
 ENV GOPATH /go
 WORKDIR /go/src

--- a/main.go
+++ b/main.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 
 	"github.com/bhoriuchi/go-bunyan/bunyan"
-	"github.com/cjimti/iotwifi/iotwifi"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+	"github.com/txn2/txwifi/iotwifi"
 )
 
 // ApiReturn structures a message for returned API calls.
@@ -25,7 +25,7 @@ type ApiReturn struct {
 func main() {
 
 	logConfig := bunyan.Config{
-		Name:   "iotwifi",
+		Name:   "txwifi",
 		Stream: os.Stdout,
 		Level:  bunyan.LogLevelDebug,
 	}


### PR DESCRIPTION
I took some time tonight and migrated all of the links/instances of cjimti/iotwif to txn2/txwifi that could safely be migrated. 

I left the docker hub links and the animations/images alone. 