### PR TITLE
Call err.Error() in ScanNetworks when scan fails

### DIFF
--- a/iotwifi/wpacfg.go
+++ b/iotwifi/wpacfg.go
@@ -255,7 +255,7 @@ func (wpa *WpaCfg) ScanNetworks() (map[string]WpaNetwork, error) {
 
 	scanOut, err := exec.Command("wpa_cli", "-i", "wlan0", "scan").Output()
 	if err != nil {
-		wpa.Log.Fatal(err)
+		wpa.Log.Fatal(err.Error())
 		return wpaNetworks, err
 	}
 	scanOutClean := strings.TrimSpace(string(scanOut))
@@ -266,7 +266,7 @@ func (wpa *WpaCfg) ScanNetworks() (map[string]WpaNetwork, error) {
 	if scanOutClean == "OK" {
 		networkListOut, err := exec.Command("wpa_cli", "-i", "wlan0", "scan_results").Output()
 		if err != nil {
-			wpa.Log.Fatal(err)
+			wpa.Log.Fatal(err.Error())
 			return wpaNetworks, err
 		}
 


### PR DESCRIPTION
Thanks for maintaining this project! I'm using it on a Raspberry Pi 4 and running into an issue while scanning for networks. Not quiet sure what it is yet but I kept encountering the stack trace below:

```
{"hostname":"kinoko","level":20,"msg":"ProcessCmd got wpa_supplicant","name":"iotwifi","pid":0,"time":"2020-03-12T13:23:29.001Z","v":0}
panic: interface conversion: interface {} is *exec.ExitError, not string
goroutine 19 [running]:
github.com/cjimti/iotwifi/vendor/github.com/bhoriuchi/go-bunyan/bunyan.(*bunyanLog).sprintf(0x11032d30, 0x11064868, 0x1, 0x1, 0x111027c0, 0x1100e4c0)
        /go/src/github.com/cjimti/iotwifi/vendor/github.com/bhoriuchi/go-bunyan/bunyan/log.go:28 +0x98
github.com/cjimti/iotwifi/vendor/github.com/bhoriuchi/go-bunyan/bunyan.(*bunyanLog).write(0x11032d30, 0x27e660, 0x6, 0x27e2f0, 0x5, 0x27e95f, 0x7, 0x3a0fb0, 0x110640d0, 0x0, ...)
        /go/src/github.com/cjimti/iotwifi/vendor/github.com/bhoriuchi/go-bunyan/bunyan/log.go:80 +0xca0
github.com/cjimti/iotwifi/vendor/github.com/bhoriuchi/go-bunyan/bunyan.(*Logger).Fatal(0x1111e360, 0x11064868, 0x1, 0x1)
        /go/src/github.com/cjimti/iotwifi/vendor/github.com/bhoriuchi/go-bunyan/bunyan/logger.go:126 +0x114
github.com/cjimti/iotwifi/iotwifi.(*WpaCfg).ScanNetworks(0x1111e360, 0x1, 0x27e2f0, 0x5)
        /go/src/github.com/cjimti/iotwifi/iotwifi/wpacfg.go:258 +0x110
github.com/cjimti/iotwifi/iotwifi.RunWifi(0x27e95f, 0x7, 0x27e2f0, 0x5, 0x3a0fb0, 0x110640d0, 0x0, 0x0, 0x0, 0x0, ...)
        /go/src/github.com/cjimti/iotwifi/iotwifi/iotwifi.go:117 +0x2b8
created by main.main
        /go/src/github.com/cjimti/iotwifi/main.go:45 +0x240
```

In other functions the `.Error()` method is called on `err` to pass a string into the logger. This PR does the same thing in the ScanNetworks method. 

Also happy to help maintain this project if y'all need more people going forward as well. I'll be using it in a few places and it's a nice tool for doing quick turn iot development.